### PR TITLE
Write progress reports to stderr, not stdout

### DIFF
--- a/src/main/java/org/unipept/tools/FunctionAnalysisPeptides.java
+++ b/src/main/java/org/unipept/tools/FunctionAnalysisPeptides.java
@@ -69,7 +69,7 @@ public class FunctionAnalysisPeptides {
             }
             done++;
             if (done % 1000000 == 0) {
-                System.out.println("FA " + done + " rows");
+                System.err.println("FA " + done + " rows");
             }
         }
         if (!m.isEmpty()) {

--- a/src/main/java/org/unipept/xml/UniprotHandler.java
+++ b/src/main/java/org/unipept/xml/UniprotHandler.java
@@ -46,7 +46,7 @@ public class UniprotHandler extends DefaultHandler {
             public void handleTag(String data) {
                 emitEntry(currentItem);
                 i++;
-                if (i % 10000 == 0) System.out.println(
+                if (i % 100000 == 0) System.err.println(
                     new Timestamp(System.currentTimeMillis())
                     + " Entry " + i + " added"
                 );


### PR DESCRIPTION
Less clutter in the output makes the time measurement more readable.