### PR TITLE
Fix double count of EC-numbers

### DIFF
--- a/.devcontainer/scripts/script.exp
+++ b/.devcontainer/scripts/script.exp
@@ -97,7 +97,7 @@ expect -exact "\r
 What's my gnu join executable (e.g. join, gjoin)? \[join\] "
 send -- "\r"
 expect -exact "\r
-Parse swissprot (http://ftp.ebi.ac.uk/pub/databases/uniprot/knowledgebase/uniprot_sprot.xml.gz)? \[Y/n\] "
+Parse swissprot (http://ftp.expasy.org/databases/uniprot/current_release/knowledgebase/complete/uniprot_sprot.xml.gz)? \[Y/n\] "
 send -- "\r"
 expect -exact "\r
 Parse trembl (http://ftp.ebi.ac.uk/pub/databases/uniprot/knowledgebase/uniprot_trembl.xml.gz)? \[Y/n\] "

--- a/configure
+++ b/configure
@@ -119,7 +119,7 @@ option "CONFIG_CMD_JOIN" "join" "What's my gnu join executable (e.g. join, gjoin
 
 sources_count="${#CONFIG_SOURCES[@]}"
 if [ "$sources_count" == "0" ]; then
-    CONFIG_SOURCES=('swissprot' 'http://ftp.ebi.ac.uk/pub/databases/uniprot/knowledgebase/uniprot_sprot.xml.gz'
+    CONFIG_SOURCES=('swissprot' 'http://ftp.expasy.org/databases/uniprot/current_release/knowledgebase/complete/uniprot_sprot.xml.gz'
                     'trembl' 'http://ftp.ebi.ac.uk/pub/databases/uniprot/knowledgebase/uniprot_trembl.xml.gz')
     sources_count=4
 fi


### PR DESCRIPTION
This PR provides a fix for #5. I've also updated the default SwissProt-URL to be using the mirror in Switzerland, which provides way faster downloads than the one we we're previously using. 

Before:
![image](https://user-images.githubusercontent.com/9608686/73753809-8eb85180-4763-11ea-94da-ca552bd87139.png)


After:
![image](https://user-images.githubusercontent.com/9608686/73753866-a4c61200-4763-11ea-8759-3459a92717d1.png)

