### PR TITLE
Add InterPro cross references index to index.sh

### DIFF
--- a/database/index.sh
+++ b/database/index.sh
@@ -59,6 +59,9 @@ print "adding index to ec_cross_references"
 doCmd "ALTER TABLE ec_cross_references ADD INDEX fk_ec_reference_uniprot_entries (uniprot_entry_id ASC);"
 # doCmd "ALTER TABLE ec_cross_references ADD INDEX fk_ec_terms_reference_go_terms_idx (ec_number_code ASC);"
 
+print "adding index to interpro_cross_references"
+doCmd "ALTER TABLE interpro_cross_references ADD INDEX fk_interpro_reference_uniprot_entries (uniprot_entry_id ASC);"
+
 print "adding index to proteomes"
 doCmd "ALTER TABLE proteomes ADD INDEX fk_taxons_proteomes (taxon_id ASC);"
 


### PR DESCRIPTION
An InterPro cross references index on the `uniprot_entries` column was not automatically added by the index.sh script. This index is required for an optimal performance in the tryptic peptide analysis application of the web app.