### PR TITLE
Strain is an unknown rank

### DIFF
--- a/makefile.in
+++ b/makefile.in
@@ -84,6 +84,7 @@ $(JAR): $(SRC)
 		-e 's/subsection/no rank/' \
 		-e 's/section/no rank/' \
 		-e 's/series/no rank/' \
+		-e 's/strain/no rank' \
 		> "$@"
 	<<<LOGADD>>> "Finished cleaning unknown ranks form nodes."
 


### PR DESCRIPTION
"Strain" appears as a rank identifier throughout the input data. This is however not a valid rank and should be filtered out when processing the data. This PR proposes a fix for issue #13.